### PR TITLE
Added X-ServiceFabric handling

### DIFF
--- a/src/Microsoft.ServiceFabric.AspNetCore/AspNetCoreCommunicationListener.cs
+++ b/src/Microsoft.ServiceFabric.AspNetCore/AspNetCoreCommunicationListener.cs
@@ -2,19 +2,19 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
-using System;
-using System.Fabric;
-using System.Fabric.Description;
-using System.Globalization;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Hosting.Server.Features;
-using Microsoft.ServiceFabric.Services.Communication.Runtime;
-
 namespace Microsoft.ServiceFabric.Services.Communication.AspNetCore
 {
+    using System;
+    using System.Fabric;
+    using System.Fabric.Description;
+    using System.Globalization;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.AspNetCore.Hosting.Server.Features;
+    using Microsoft.ServiceFabric.Services.Communication.Runtime;
+
     /// <summary>
     /// Base class for creating AspNetCore based communication listener for Service Fabric stateless or stateful service.
     /// </summary>

--- a/src/Microsoft.ServiceFabric.AspNetCore/AspNetCoreCommunicationListener.cs
+++ b/src/Microsoft.ServiceFabric.AspNetCore/AspNetCoreCommunicationListener.cs
@@ -2,19 +2,19 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
+using System;
+using System.Fabric;
+using System.Fabric.Description;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.ServiceFabric.Services.Communication.Runtime;
+
 namespace Microsoft.ServiceFabric.Services.Communication.AspNetCore
 {
-    using System;
-    using System.Fabric;
-    using System.Fabric.Description;
-    using System.Linq;
-    using System.Globalization;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.AspNetCore.Hosting.Server.Features;
-    using Microsoft.ServiceFabric.Services.Communication.Runtime;
-
     /// <summary>
     /// Base class for creating AspNetCore based communication listener for Service Fabric stateless or stateful service.
     /// </summary>

--- a/src/Microsoft.ServiceFabric.AspNetCore/Microsoft.ServiceFabric.AspNetCore.csproj
+++ b/src/Microsoft.ServiceFabric.AspNetCore/Microsoft.ServiceFabric.AspNetCore.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Friend.cs" />
     <Compile Include="ServiceFabricIntegrationOptions.cs" />
     <Compile Include="ServiceFabricMiddleware.cs" />
+    <Compile Include="ServiceFabricReverseProxyIntegrationMiddleware.cs" />
     <Compile Include="ServiceFabricSetupFilter.cs" />
     <Compile Include="SR.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/Microsoft.ServiceFabric.AspNetCore/ServiceFabricIntegrationOptions.cs
+++ b/src/Microsoft.ServiceFabric.AspNetCore/ServiceFabricIntegrationOptions.cs
@@ -2,10 +2,10 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
-using System;
-
 namespace Microsoft.ServiceFabric.Services.Communication.AspNetCore
 {
+    using System;
+
     /// <summary>
     /// Integration options for <see cref="WebHostBuilderServiceFabricExtension.UseServiceFabricIntegration"/> method when used with Microsoft.AspNetCore.Hosting.IWebHostBuilder.
     /// </summary>

--- a/src/Microsoft.ServiceFabric.AspNetCore/ServiceFabricIntegrationOptions.cs
+++ b/src/Microsoft.ServiceFabric.AspNetCore/ServiceFabricIntegrationOptions.cs
@@ -2,14 +2,10 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
+using System;
+
 namespace Microsoft.ServiceFabric.Services.Communication.AspNetCore
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-
     /// <summary>
     /// Integration options for <see cref="WebHostBuilderServiceFabricExtension.UseServiceFabricIntegration"/> method when used with Microsoft.AspNetCore.Hosting.IWebHostBuilder.
     /// </summary>
@@ -25,6 +21,11 @@ namespace Microsoft.ServiceFabric.Services.Communication.AspNetCore
         /// This option will configure the <see cref="AspNetCoreCommunicationListener"/> to add a url suffix containing <see cref="System.Fabric.ServiceContext.PartitionId"/> and <see cref="System.Fabric.ServiceContext.ReplicaOrInstanceId"/>
         /// to url when providing the url to Service Fabric Runtime from its <see cref="Microsoft.ServiceFabric.Services.Communication.Runtime.ICommunicationListener.OpenAsync"/> method.
         /// </summary>
-        UseUniqueServiceUrl = 0x01
+        UseUniqueServiceUrl = 0x01,
+
+        /// <summary>
+        /// This option will enable the Service Fabric Reverse Proxy integration middleware.
+        /// </summary>
+        UseReverseProxyIntegration = 0x02
     }
 }

--- a/src/Microsoft.ServiceFabric.AspNetCore/ServiceFabricMiddleware.cs
+++ b/src/Microsoft.ServiceFabric.AspNetCore/ServiceFabricMiddleware.cs
@@ -2,13 +2,13 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
 namespace Microsoft.ServiceFabric.Services.Communication.AspNetCore
 {
-    using System;
-    using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.AspNetCore.Builder;
-
     /// <summary>
     /// A middleware to be used with Service Fabric stateful and stateless services hosted in Kestrel or WebListener.
     /// This middleware examines the Microsoft.AspNetCore.Http.HttpRequest.Path in request to determine if the request is intended for this replica.
@@ -85,16 +85,6 @@ namespace Microsoft.ServiceFabric.Services.Communication.AspNetCore
                     return;
                 }
 
-                context.Response.OnStarting(() =>
-                {
-                    if (context.Response.StatusCode == StatusCodes.Status404NotFound)
-                    {
-                        context.Response.Headers["X-ServiceFabric"] = "ResourceNotFound";
-                    }
-                    //TODO: When upgraded to .NET Standard 2.0 replace with Task.CompletedTask to avoid unnecessary allocation
-                    return Task.FromResult<object>(null);
-                });
-
                 // All good, change Path, PathBase and call next middleware in the pipeline
                 var originalPath = context.Request.Path;
                 var originalPathBase = context.Request.PathBase;
@@ -121,7 +111,7 @@ namespace Microsoft.ServiceFabric.Services.Communication.AspNetCore
     public static class ServiceFabricMiddlewareExtensions
     {
         /// <summary>
-        /// Extension method to use ServiceFabricKestrelMiddleware for Service Fabric stateful or stateless service
+        /// Extension method to use ServiceFabricMiddleware for Service Fabric stateful or stateless service
         /// using Kestrel or WebListener as WebServer.
         /// </summary>
         /// <param name="builder">Microsoft.AspNetCore.Builder.IApplicationBuilder</param>        

--- a/src/Microsoft.ServiceFabric.AspNetCore/ServiceFabricMiddleware.cs
+++ b/src/Microsoft.ServiceFabric.AspNetCore/ServiceFabricMiddleware.cs
@@ -85,6 +85,16 @@ namespace Microsoft.ServiceFabric.Services.Communication.AspNetCore
                     return;
                 }
 
+                context.Response.OnStarting(() =>
+                {
+                    if (context.Response.StatusCode == StatusCodes.Status404NotFound)
+                    {
+                        context.Response.Headers["X-ServiceFabric"] = "ResourceNotFound";
+                    }
+                    //TODO: When upgraded to .NET Standard 2.0 replace with Task.CompletedTask to avoid unnecessary allocation
+                    return Task.FromResult<object>(null);
+                });
+
                 // All good, change Path, PathBase and call next middleware in the pipeline
                 var originalPath = context.Request.Path;
                 var originalPathBase = context.Request.PathBase;

--- a/src/Microsoft.ServiceFabric.AspNetCore/ServiceFabricMiddleware.cs
+++ b/src/Microsoft.ServiceFabric.AspNetCore/ServiceFabricMiddleware.cs
@@ -2,13 +2,13 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
-using System;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
-
 namespace Microsoft.ServiceFabric.Services.Communication.AspNetCore
 {
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Http;
+
     /// <summary>
     /// A middleware to be used with Service Fabric stateful and stateless services hosted in Kestrel or WebListener.
     /// This middleware examines the Microsoft.AspNetCore.Http.HttpRequest.Path in request to determine if the request is intended for this replica.

--- a/src/Microsoft.ServiceFabric.AspNetCore/ServiceFabricReverseProxyIntegrationMiddleware.cs
+++ b/src/Microsoft.ServiceFabric.AspNetCore/ServiceFabricReverseProxyIntegrationMiddleware.cs
@@ -2,19 +2,22 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
-using System;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
-
 namespace Microsoft.ServiceFabric.Services.Communication.AspNetCore
 {
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Http;
+
     /// <summary>
     /// A middleware to be used with Service Fabric stateful and stateless services hosted in Kestrel or WebListener.
     /// This middleware automatically adds X-ServiceFabric ResourceNotFound header, required by the Service Fabric Reverse Proxy, when 404 status code is returned
     /// </summary>
     public class ServiceFabricReverseProxyIntegrationMiddleware
     {
+        private const string XServiceFabricHeader = "X-ServiceFabric";
+        private const string XServiceFabricResourceNotFoundValue = "ResourceNotFound";
+
         private readonly RequestDelegate next;
 
         /// <summary>
@@ -47,7 +50,7 @@ namespace Microsoft.ServiceFabric.Services.Communication.AspNetCore
             {
                 if (context.Response.StatusCode == StatusCodes.Status404NotFound)
                 {
-                    context.Response.Headers["X-ServiceFabric"] = "ResourceNotFound";
+                    context.Response.Headers[XServiceFabricHeader] = XServiceFabricResourceNotFoundValue;
                 }
                 //TODO: When upgraded to .NET Standard 2.0 replace with Task.CompletedTask to avoid unnecessary allocation
                 return Task.FromResult<object>(null);

--- a/src/Microsoft.ServiceFabric.AspNetCore/ServiceFabricReverseProxyIntegrationMiddleware.cs
+++ b/src/Microsoft.ServiceFabric.AspNetCore/ServiceFabricReverseProxyIntegrationMiddleware.cs
@@ -1,0 +1,82 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.ServiceFabric.Services.Communication.AspNetCore
+{
+    /// <summary>
+    /// A middleware to be used with Service Fabric stateful and stateless services hosted in Kestrel or WebListener.
+    /// This middleware automatically adds X-ServiceFabric ResourceNotFound header, required by the Service Fabric Reverse Proxy, when 404 status code is returned
+    /// </summary>
+    public class ServiceFabricReverseProxyIntegrationMiddleware
+    {
+        private readonly RequestDelegate next;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="ServiceFabricReverseProxyIntegrationMiddleware"/>
+        /// </summary>
+        /// <param name="next">Next request handler in pipeline.</param>
+        public ServiceFabricReverseProxyIntegrationMiddleware(RequestDelegate next)
+        {
+            if (next == null)
+            {
+                throw new ArgumentNullException(nameof(next));
+            }
+
+            this.next = next;
+        }
+
+        /// <summary>
+        /// Invoke.
+        /// </summary>
+        /// <param name="context">Context.</param>
+        /// <returns>Task for the execution by next middleware in pipeline.</returns>
+        public Task Invoke(HttpContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            context.Response.OnStarting(() =>
+            {
+                if (context.Response.StatusCode == StatusCodes.Status404NotFound)
+                {
+                    context.Response.Headers["X-ServiceFabric"] = "ResourceNotFound";
+                }
+                //TODO: When upgraded to .NET Standard 2.0 replace with Task.CompletedTask to avoid unnecessary allocation
+                return Task.FromResult<object>(null);
+            });
+
+            return next(context);
+        }
+    }
+
+    /// <summary>
+    /// Extension class to use ServiceFabricReverseProxyIntegrationMiddleware for Service Fabric stateful or stateless service
+    /// using Kestrel or WebListener as WebServer.
+    /// </summary>
+    public static class ServiceFabricReverseProxyIntegrationMiddlewareExtensions
+    {
+        /// <summary>
+        /// Extension method to use ServiceFabricReverseProxyIntegrationMiddleware for Service Fabric stateful or stateless service
+        /// using Kestrel or WebListener as WebServer.
+        /// </summary>
+        /// <param name="builder">Microsoft.AspNetCore.Builder.IApplicationBuilder</param>        
+        /// <returns>Microsoft.AspNetCore.Builder.IApplicationBuilder</returns>
+        public static IApplicationBuilder UseServiceFabricReverseProxyIntegrationMiddleware(this IApplicationBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return builder.UseMiddleware<ServiceFabricReverseProxyIntegrationMiddleware>();
+        }
+    }
+}

--- a/src/Microsoft.ServiceFabric.AspNetCore/ServiceFabricSetupFilter.cs
+++ b/src/Microsoft.ServiceFabric.AspNetCore/ServiceFabricSetupFilter.cs
@@ -2,19 +2,21 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
+using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+
 namespace Microsoft.ServiceFabric.Services.Communication.AspNetCore
 {
-    using System;
-    using Microsoft.AspNetCore.Builder;
-    using Microsoft.AspNetCore.Hosting;
-
     internal class ServiceFabricSetupFilter : IStartupFilter
     {
         private readonly string urlSuffix;
+        private readonly bool enableReverseProxyIntegration;
 
-        internal ServiceFabricSetupFilter(string urlSuffix)
+        internal ServiceFabricSetupFilter(string urlSuffix, bool enableReverseProxyIntegration)
         {
             this.urlSuffix = urlSuffix;
+            this.enableReverseProxyIntegration = enableReverseProxyIntegration;
         }
 
         public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
@@ -22,6 +24,10 @@ namespace Microsoft.ServiceFabric.Services.Communication.AspNetCore
             return app =>
             {
                 app.UseServiceFabricMiddleware(this.urlSuffix);
+                if (enableReverseProxyIntegration)
+                {
+                    app.UseServiceFabricReverseProxyIntegrationMiddleware();
+                }
                 next(app);
             };
         }

--- a/src/Microsoft.ServiceFabric.AspNetCore/ServiceFabricSetupFilter.cs
+++ b/src/Microsoft.ServiceFabric.AspNetCore/ServiceFabricSetupFilter.cs
@@ -2,21 +2,21 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
-using System;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-
 namespace Microsoft.ServiceFabric.Services.Communication.AspNetCore
 {
+    using System;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+
     internal class ServiceFabricSetupFilter : IStartupFilter
     {
         private readonly string urlSuffix;
-        private readonly bool enableReverseProxyIntegration;
+        private readonly ServiceFabricIntegrationOptions options;
 
-        internal ServiceFabricSetupFilter(string urlSuffix, bool enableReverseProxyIntegration)
+        internal ServiceFabricSetupFilter(string urlSuffix, ServiceFabricIntegrationOptions options)
         {
             this.urlSuffix = urlSuffix;
-            this.enableReverseProxyIntegration = enableReverseProxyIntegration;
+            this.options = options;
         }
 
         public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
@@ -24,7 +24,7 @@ namespace Microsoft.ServiceFabric.Services.Communication.AspNetCore
             return app =>
             {
                 app.UseServiceFabricMiddleware(this.urlSuffix);
-                if (enableReverseProxyIntegration)
+                if (options.HasFlag(ServiceFabricIntegrationOptions.UseReverseProxyIntegration))
                 {
                     app.UseServiceFabricReverseProxyIntegrationMiddleware();
                 }

--- a/src/Microsoft.ServiceFabric.AspNetCore/WebHostBuilderServiceFabricExtension.cs
+++ b/src/Microsoft.ServiceFabric.AspNetCore/WebHostBuilderServiceFabricExtension.cs
@@ -2,13 +2,12 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
+using System;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
 namespace Microsoft.ServiceFabric.Services.Communication.AspNetCore
 {
-    using System;
-    using System.Fabric;
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.Extensions.DependencyInjection;
-
     /// <summary>
     /// Class containing Service Fabric related extension methods for Microsoft.AspNetCore.Hosting.IWebHostBuilder
     /// </summary>
@@ -41,7 +40,7 @@ namespace Microsoft.ServiceFabric.Services.Communication.AspNetCore
             hostBuilder.UseSetting(SettingName, true.ToString());
 
             // Configure listener to use PartitionId and ReplicaId as urlSuffix only when specified in options.
-            if (options.Equals(ServiceFabricIntegrationOptions.UseUniqueServiceUrl))
+            if (options.HasFlag(ServiceFabricIntegrationOptions.UseUniqueServiceUrl))
             {
                 // notify listener to use urlSuffix when giving url to Service Fabric Runtime from OpenAsync()
                 listener.ConfigureToUseUniqueServiceUrl();
@@ -50,7 +49,7 @@ namespace Microsoft.ServiceFabric.Services.Communication.AspNetCore
             hostBuilder.ConfigureServices(services =>
             {
                 // Configure MiddleWare
-                services.AddSingleton<IStartupFilter>(new ServiceFabricSetupFilter(listener.UrlSuffix));
+                services.AddSingleton<IStartupFilter>(new ServiceFabricSetupFilter(listener.UrlSuffix, options.HasFlag(ServiceFabricIntegrationOptions.UseReverseProxyIntegration)));
             });
 
             return hostBuilder;

--- a/src/Microsoft.ServiceFabric.AspNetCore/WebHostBuilderServiceFabricExtension.cs
+++ b/src/Microsoft.ServiceFabric.AspNetCore/WebHostBuilderServiceFabricExtension.cs
@@ -2,12 +2,12 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
-using System;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.DependencyInjection;
-
 namespace Microsoft.ServiceFabric.Services.Communication.AspNetCore
 {
+    using System;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.Extensions.DependencyInjection;
+
     /// <summary>
     /// Class containing Service Fabric related extension methods for Microsoft.AspNetCore.Hosting.IWebHostBuilder
     /// </summary>
@@ -49,7 +49,7 @@ namespace Microsoft.ServiceFabric.Services.Communication.AspNetCore
             hostBuilder.ConfigureServices(services =>
             {
                 // Configure MiddleWare
-                services.AddSingleton<IStartupFilter>(new ServiceFabricSetupFilter(listener.UrlSuffix, options.HasFlag(ServiceFabricIntegrationOptions.UseReverseProxyIntegration)));
+                services.AddSingleton<IStartupFilter>(new ServiceFabricSetupFilter(listener.UrlSuffix, options));
             });
 
             return hostBuilder;


### PR DESCRIPTION
This resolves #2 

I have decided to add this to the existing Service Fabric integration middleware to make it as transparent to the user as possible.

There might be a possibility it is not a desired behavior for some corner cases. For example if someone wants to heavily use prefix sharing. We can provide opt-out option in that case.

Currently developer can create his/her own middleware after ServiceFabricIntegration middleware and strip X-ServiceFabric header.