### PR TITLE
Removing the hard version check from configuration package and allowing any version above the current one

### DIFF
--- a/nuprojs/Microsoft.ServiceFabric.AspNetCore.Configuration/Microsoft.ServiceFabric.AspNetCore.Configuration.nuproj
+++ b/nuprojs/Microsoft.ServiceFabric.AspNetCore.Configuration/Microsoft.ServiceFabric.AspNetCore.Configuration.nuproj
@@ -72,7 +72,7 @@
     
     <ItemGroup>
       <Dependency Include="Microsoft.ServiceFabric.Services">
-        <Version>[$(NugetPkg_Version_Microsoft_ServiceFabric_Services)]</Version>
+        <Version>$(NugetPkg_Version_Microsoft_ServiceFabric_Services)</Version>
       </Dependency>
       <Dependency Include="Microsoft.Extensions.Configuration">
         <Version>1.0.0</Version>


### PR DESCRIPTION
Removing the hard version check and allowing any version above the current one. 

Fixes https://github.com/Microsoft/service-fabric-aspnetcore/issues/61