### PR TITLE
Change project URL to https://github.com/microsoft/service-fabric-aspnetcore/

### DIFF
--- a/properties/service_fabric_nuget.props
+++ b/properties/service_fabric_nuget.props
@@ -10,7 +10,7 @@
   <PropertyGroup>
     <Authors>Microsoft</Authors>
     <Owners>Microsoft,ServiceFabric</Owners>
-    <ProjectUrl>http://aka.ms/servicefabric</ProjectUrl>
+    <ProjectUrl>https://github.com/microsoft/service-fabric-aspnetcore/</ProjectUrl>
     <LicenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</LicenseUrl>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <RequireLicenseAcceptance>True</RequireLicenseAcceptance>


### PR DESCRIPTION
NuGet information is consumed by developers.

When a developer looks for the project URL, the developer is looking for the project to look at the code, not product marketing.