### PR TITLE
ServiceFabricConfigurationProvider should only load configuration from the ConfigPackage to which it is mapped

### DIFF
--- a/code.sln
+++ b/code.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2027
+# Visual Studio 2019
+VisualStudioVersion = 16.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dotnetstandard", "dotnetstandard", "{DFB5E99B-B17D-4FD4-8CA8-24C399606962}"
 EndProject

--- a/src/Microsoft.ServiceFabric.AspNetCore.Configuration/ServiceFabricConfigurationProvider.cs
+++ b/src/Microsoft.ServiceFabric.AspNetCore.Configuration/ServiceFabricConfigurationProvider.cs
@@ -23,14 +23,12 @@ namespace Microsoft.ServiceFabric.AspNetCore.Configuration
 
             this.context.ConfigurationPackageModifiedEvent += (sender, e) =>
             {
-                this.LoadPackage(e.NewPackage, reload: true);
-                this.OnReload(); // Notify the change
+                this.HandleNewPackage(e.NewPackage);
             };
 
             this.context.ConfigurationPackageAddedEvent += (sender, e) =>
             {
-                this.LoadPackage(e.Package, reload: true);
-                this.OnReload(); // Notify the change
+                this.HandleNewPackage(e.Package);
             };
         }
 
@@ -41,6 +39,16 @@ namespace Microsoft.ServiceFabric.AspNetCore.Configuration
         {
             var config = this.context.GetConfigurationPackageObject(this.options.PackageName);
             this.LoadPackage(config);
+        }
+
+        private void HandleNewPackage(ConfigurationPackage package)
+        {
+            // Load configuration from new package only if it is the ConfigPackage mapped to this provider
+            if (package.Description.Name == this.options.PackageName)
+            {
+                this.LoadPackage(package, reload: true);
+                this.OnReload(); // Notify the change
+            }
         }
 
         private void LoadPackage(ConfigurationPackage config, bool reload = false)

--- a/src/Microsoft.ServiceFabric.AspNetCore.Configuration/ServiceFabricConfigurationProvider.cs
+++ b/src/Microsoft.ServiceFabric.AspNetCore.Configuration/ServiceFabricConfigurationProvider.cs
@@ -41,8 +41,17 @@ namespace Microsoft.ServiceFabric.AspNetCore.Configuration
             this.LoadPackage(config);
         }
 
+        /// <summary>
+        /// Handle loading of a new package provided by a ConfigurationPackageModifiedEvent or a ConfigurationPackageAddedEvent
+        /// </summary>
+        /// <param name="package">The new package to load from</param>
         private void HandleNewPackage(ConfigurationPackage package)
         {
+            if (package.Description is null)
+            {
+                throw new ArgumentNullException($"{nameof(package)}.Description", $"A valid Description must be provided with {nameof(package)}.");
+            }
+
             // Load configuration from new package only if it is the ConfigPackage mapped to this provider
             if (package.Description.Name == this.options.PackageName)
             {
@@ -51,7 +60,12 @@ namespace Microsoft.ServiceFabric.AspNetCore.Configuration
             }
         }
 
-        private void LoadPackage(ConfigurationPackage config, bool reload = false)
+        /// <summary>
+        /// Load and populate data from <paramref name="package"/>.
+        /// </summary>
+        /// <param name="package">The package to load from.</param>
+        /// <param name="reload">Whether or not to completely refresh <see cref="Data"/>.</param>
+        private void LoadPackage(ConfigurationPackage package, bool reload = false)
         {
             if (reload)
             {
@@ -59,7 +73,7 @@ namespace Microsoft.ServiceFabric.AspNetCore.Configuration
             }
 
             // call the delegate action to populate the Data
-            this.options.ConfigAction(config, this.Data);
+            this.options.ConfigAction(package, this.Data);
         }
     }
 }

--- a/src/Microsoft.ServiceFabric.AspNetCore.Configuration/ServiceFabricConfigurationProvider.cs
+++ b/src/Microsoft.ServiceFabric.AspNetCore.Configuration/ServiceFabricConfigurationProvider.cs
@@ -42,9 +42,9 @@ namespace Microsoft.ServiceFabric.AspNetCore.Configuration
         }
 
         /// <summary>
-        /// Handle loading of a new package provided by a ConfigurationPackageModifiedEvent or a ConfigurationPackageAddedEvent
+        /// Handle loading of a new package provided by a ConfigurationPackageModifiedEvent or a ConfigurationPackageAddedEvent.
         /// </summary>
-        /// <param name="package">The new package to load from</param>
+        /// <param name="package">The new package to load from.</param>
         private void HandleNewPackage(ConfigurationPackage package)
         {
             if (package.Description is null)

--- a/test/unittests/Microsoft.ServiceFabric.AspNetCore.Tests/Mocks/MockConfigurationPackage.cs
+++ b/test/unittests/Microsoft.ServiceFabric.AspNetCore.Tests/Mocks/MockConfigurationPackage.cs
@@ -19,9 +19,12 @@ namespace Microsoft.ServiceFabric.AspNetCore.Tests
         {
             var package = TestHelper.CreateInstanced<ConfigurationPackage>();
             var settings = TestHelper.CreateInstanced<ConfigurationSettings>();
+            var desc = TestHelper.CreateInstanced<ConfigurationPackageDescription>();
             var basePath = Environment.CurrentDirectory;
+            desc.Set("Name", packageName);
             package.Set("Settings", settings);
-            package.Set("Path", $"{basePath}\\PackageRoot\\Config\\");
+            package.Set("Path", $"{basePath}\\{packageName}\\PackageRoot\\Config\\");
+            package.Set("Description", desc);
 
             var section = TestHelper.CreateInstanced<System.Fabric.Description.ConfigurationSection>();
             settings.Set(nameof(ConfigurationSettings.Sections), MockConfigurationSections.CreateDefault(config));

--- a/test/unittests/Microsoft.ServiceFabric.AspNetCore.Tests/Mocks/TestCodePackageActivationContext.cs
+++ b/test/unittests/Microsoft.ServiceFabric.AspNetCore.Tests/Mocks/TestCodePackageActivationContext.cs
@@ -166,10 +166,11 @@ namespace Microsoft.ServiceFabric.AspNetCore.Tests
         /// Triggers the configuration package modified event.
         /// </summary>
         /// <param name="configurationRoot">The configuration root.</param>
-        public void TriggerConfigurationPackageModifiedEvent(IConfigurationRoot configurationRoot)
+        /// <param name="packageName">The name of the package.</param>
+        public void TriggerConfigurationPackageModifiedEvent(IConfigurationRoot configurationRoot, string packageName)
         {
-            var oldPackage = this.GetConfigurationPackageObject("Config");
-            var newPackage = MockConfigurationPackage.CreateDefaultPackage(configurationRoot, "Config");
+            var oldPackage = this.GetConfigurationPackageObject(packageName);
+            var newPackage = MockConfigurationPackage.CreateDefaultPackage(configurationRoot, packageName);
             this.ConfigurationPackageModifiedEvent(this, new PackageModifiedEventArgs<ConfigurationPackage>() { OldPackage = oldPackage, NewPackage = newPackage });
         }
 


### PR DESCRIPTION
Fixes #93 

This issue is easily reproducible if you comment out my fix and run the updated unit test. It will fail because *both* providers will load from the new package (when only the provider that is mapped to Config1 should have reloaded).