### PR TITLE
Add net8.0 to SDK v8

### DIFF
--- a/nuprojs/Microsoft.ServiceFabric.AspNetCore.Abstractions/Microsoft.ServiceFabric.AspNetCore.Abstractions.nuproj
+++ b/nuprojs/Microsoft.ServiceFabric.AspNetCore.Abstractions/Microsoft.ServiceFabric.AspNetCore.Abstractions.nuproj
@@ -63,6 +63,12 @@
       <File Include="$(DropFolderNet7)Microsoft.ServiceFabric.AspNetCore.dll">
         <TargetPath>lib\net7.0</TargetPath>
       </File>
+      <File Include="$(DropFolderNet8)Microsoft.ServiceFabric.AspNetCore.xml">
+        <TargetPath>lib\net8.0</TargetPath>
+      </File>
+      <File Include="$(DropFolderNet8)Microsoft.ServiceFabric.AspNetCore.dll">
+        <TargetPath>lib\net8.0</TargetPath>
+      </File>
       <File Include="$(DropFolderNetFramework)Microsoft.ServiceFabric.AspNetCore.dll">
         <TargetPath>runtimes\win\lib\net462</TargetPath>
       </File>
@@ -108,6 +114,14 @@
       </Dependency>
       <FrameworkReference Include="Microsoft.AspNetCore.App">
         <TargetFramework>net7.0</TargetFramework>
+      </FrameworkReference>
+
+      <Dependency Include="Microsoft.ServiceFabric.Services">
+        <Version>[$(NugetPkg_Version_Microsoft_ServiceFabric_Services)]</Version>
+        <TargetFramework>net8.0</TargetFramework>
+      </Dependency>
+      <FrameworkReference Include="Microsoft.AspNetCore.App">
+        <TargetFramework>net8.0</TargetFramework>
       </FrameworkReference>
 
       <Dependency Include="Microsoft.ServiceFabric.Services">

--- a/nuprojs/Microsoft.ServiceFabric.AspNetCore.Configuration/Microsoft.ServiceFabric.AspNetCore.Configuration.nuproj
+++ b/nuprojs/Microsoft.ServiceFabric.AspNetCore.Configuration/Microsoft.ServiceFabric.AspNetCore.Configuration.nuproj
@@ -63,6 +63,12 @@
       <File Include="$(DropFolderNet7)Microsoft.ServiceFabric.AspNetCore.Configuration.xml">
         <TargetPath>lib\net7.0</TargetPath>
       </File>
+      <File Include="$(DropFolderNet8)Microsoft.ServiceFabric.AspNetCore.Configuration.dll">
+        <TargetPath>lib\net8.0</TargetPath>
+      </File>
+      <File Include="$(DropFolderNet8)Microsoft.ServiceFabric.AspNetCore.Configuration.xml">
+        <TargetPath>lib\net8.0</TargetPath>
+      </File>
       <File Include="$(DropFolderNetFramework)Microsoft.ServiceFabric.AspNetCore.Configuration.dll">
         <TargetPath>runtimes\win\lib\net462</TargetPath>
       </File>
@@ -108,6 +114,14 @@
       </Dependency>
       <FrameworkReference Include="Microsoft.AspNetCore.App">
         <TargetFramework>net7.0</TargetFramework>
+      </FrameworkReference>
+
+      <Dependency Include="Microsoft.ServiceFabric.Services">
+        <Version>[$(NugetPkg_Version_Microsoft_ServiceFabric_Services)]</Version>
+        <TargetFramework>net8.0</TargetFramework>
+      </Dependency>
+      <FrameworkReference Include="Microsoft.AspNetCore.App">
+        <TargetFramework>net8.0</TargetFramework>
       </FrameworkReference>
 
       <Dependency Include="Microsoft.ServiceFabric.Services">

--- a/nuprojs/Microsoft.ServiceFabric.AspNetCore.HttpSys/Microsoft.ServiceFabric.AspNetCore.HttpSys.nuproj
+++ b/nuprojs/Microsoft.ServiceFabric.AspNetCore.HttpSys/Microsoft.ServiceFabric.AspNetCore.HttpSys.nuproj
@@ -63,6 +63,12 @@
       <File Include="$(DropFolderNet7)Microsoft.ServiceFabric.AspNetCore.HttpSys.xml">
         <TargetPath>lib\net7.0</TargetPath>
       </File>
+      <File Include="$(DropFolderNet8)Microsoft.ServiceFabric.AspNetCore.HttpSys.dll">
+        <TargetPath>lib\net8.0</TargetPath>
+      </File>
+      <File Include="$(DropFolderNet8)Microsoft.ServiceFabric.AspNetCore.HttpSys.xml">
+        <TargetPath>lib\net8.0</TargetPath>
+      </File>
       <File Include="$(DropFolderNetFramework)Microsoft.ServiceFabric.AspNetCore.HttpSys.dll">
         <TargetPath>runtimes\win\lib\net462</TargetPath>
       </File>
@@ -108,6 +114,14 @@
       </Dependency>
       <FrameworkReference Include="Microsoft.AspNetCore.App">
         <TargetFramework>net7.0</TargetFramework>
+      </FrameworkReference>
+
+      <Dependency Include="Microsoft.ServiceFabric.AspNetCore.Abstractions">
+        <Version>[$(NuGetPackageVersion)]</Version>
+        <TargetFramework>net8.0</TargetFramework>
+      </Dependency>
+      <FrameworkReference Include="Microsoft.AspNetCore.App">
+        <TargetFramework>net8.0</TargetFramework>
       </FrameworkReference>
 
       <Dependency Include="Microsoft.ServiceFabric.AspNetCore.Abstractions">

--- a/nuprojs/Microsoft.ServiceFabric.AspNetCore.HttpSys/Microsoft.ServiceFabric.AspNetCore.HttpSys.nuproj
+++ b/nuprojs/Microsoft.ServiceFabric.AspNetCore.HttpSys/Microsoft.ServiceFabric.AspNetCore.HttpSys.nuproj
@@ -129,7 +129,7 @@
         <TargetFramework>net462</TargetFramework>
       </Dependency>
       <Dependency Include="Microsoft.AspNetCore.Server.HttpSys">
-        <Version>2.1.0</Version>
+        <Version>2.1.12</Version>
         <TargetFramework>net462</TargetFramework>
       </Dependency>
     </ItemGroup>

--- a/nuprojs/Microsoft.ServiceFabric.AspNetCore.Kestrel/Microsoft.ServiceFabric.AspNetCore.Kestrel.nuproj
+++ b/nuprojs/Microsoft.ServiceFabric.AspNetCore.Kestrel/Microsoft.ServiceFabric.AspNetCore.Kestrel.nuproj
@@ -63,6 +63,12 @@
       <File Include="$(DropFolderNet7)Microsoft.ServiceFabric.AspNetCore.Kestrel.xml">
        <TargetPath>lib\net7.0</TargetPath>
       </File>
+      <File Include="$(DropFolderNet8)Microsoft.ServiceFabric.AspNetCore.Kestrel.dll">
+        <TargetPath>lib\net8.0</TargetPath>
+      </File>
+      <File Include="$(DropFolderNet8)Microsoft.ServiceFabric.AspNetCore.Kestrel.xml">
+       <TargetPath>lib\net8.0</TargetPath>
+      </File>
       <File Include="$(DropFolderNetFramework)Microsoft.ServiceFabric.AspNetCore.Kestrel.dll">
         <TargetPath>runtimes\win\lib\net462</TargetPath>
       </File>
@@ -108,6 +114,14 @@
       </Dependency>
       <FrameworkReference Include="Microsoft.AspNetCore.App">
         <TargetFramework>net7.0</TargetFramework>
+      </FrameworkReference>
+
+      <Dependency Include="Microsoft.ServiceFabric.AspNetCore.Abstractions">
+        <Version>[$(NuGetPackageVersion)]</Version>
+        <TargetFramework>net8.0</TargetFramework>
+      </Dependency>
+      <FrameworkReference Include="Microsoft.AspNetCore.App">
+        <TargetFramework>net8.0</TargetFramework>
       </FrameworkReference>
 
       <Dependency Include="Microsoft.ServiceFabric.AspNetCore.Abstractions">

--- a/nuprojs/SF.AspNetCore.Internal/SF.AspNetCore.Internal.nuproj
+++ b/nuprojs/SF.AspNetCore.Internal/SF.AspNetCore.Internal.nuproj
@@ -30,5 +30,8 @@
       <File Include="$(DropFolderNet7)*.*">
         <TargetPath>lib\net7.0</TargetPath>
       </File>
+      <File Include="$(DropFolderNet8)*.*">
+        <TargetPath>lib\net8.0</TargetPath>
+      </File>
     </ItemGroup>    
   </Project>

--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -31,7 +31,7 @@
     <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->
     <MajorVersion>8</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <BuildVersion>0</BuildVersion>
+    <BuildVersion>1</BuildVersion>
     <Revision>0</Revision>
 
   </PropertyGroup>

--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -17,6 +17,7 @@
     <DropFolderNet5>$(RepoRoot)drop\$(Configuration)\net5.0\</DropFolderNet5>
     <DropFolderNet6>$(RepoRoot)drop\$(Configuration)\net6.0\</DropFolderNet6>
     <DropFolderNet7>$(RepoRoot)drop\$(Configuration)\net7.0\</DropFolderNet7>
+    <DropFolderNet8>$(RepoRoot)drop\$(Configuration)\net8.0\</DropFolderNet8>
     <NugetPackageDropFolder>$(DropFolder)\packages</NugetPackageDropFolder>
 
     <!-- Set Nuget exe path -->

--- a/properties/service_fabric_managed.targets
+++ b/properties/service_fabric_managed.targets
@@ -87,6 +87,14 @@
       <BinariesNet7 Include="src\Microsoft.ServiceFabric.AspNetCore.Kestrel\$(OutputPath)net7.0\Microsoft.ServiceFabric.AspNetCore.Kestrel.*"/>
     </ItemGroup>
     <Copy SourceFiles="@(BinariesNet7)" DestinationFiles="@(BinariesNet7->'$(DropFolderNet7)\%(Destination)\%(RecursiveDir)%(Filename)%(Extension)')" />
+
+    <ItemGroup>
+      <BinariesNet8 Include="src\Microsoft.ServiceFabric.AspNetCore\$(OutputPath)net8.0\Microsoft.ServiceFabric.AspNetCore.*"/>
+      <BinariesNet8 Include="src\Microsoft.ServiceFabric.AspNetCore.Configuration\$(OutputPath)net8.0\Microsoft.ServiceFabric.AspNetCore.Configuration.*"/>
+      <BinariesNet8 Include="src\Microsoft.ServiceFabric.AspNetCore.HttpSys\$(OutputPath)net8.0\Microsoft.ServiceFabric.AspNetCore.HttpSys.*"/>
+      <BinariesNet8 Include="src\Microsoft.ServiceFabric.AspNetCore.Kestrel\$(OutputPath)net8.0\Microsoft.ServiceFabric.AspNetCore.Kestrel.*"/>
+    </ItemGroup>
+    <Copy SourceFiles="@(BinariesNet8)" DestinationFiles="@(BinariesNet8->'$(DropFolderNet8)\%(Destination)\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
    
 </Project>

--- a/src/Microsoft.ServiceFabric.AspNetCore.Configuration/Microsoft.ServiceFabric.AspNetCore.Configuration.csproj
+++ b/src/Microsoft.ServiceFabric.AspNetCore.Configuration/Microsoft.ServiceFabric.AspNetCore.Configuration.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Microsoft.ServiceFabric.AspNetCore.Configuration</AssemblyName>
     <RootNamespace>Microsoft.ServiceFabric.AspNetCore.Configuration</RootNamespace>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric.Services" Version="$(NugetPkg_Version_Microsoft_ServiceFabric_Services)" />

--- a/src/Microsoft.ServiceFabric.AspNetCore.HttpSys/Microsoft.ServiceFabric.AspNetCore.HttpSys.csproj
+++ b/src/Microsoft.ServiceFabric.AspNetCore.HttpSys/Microsoft.ServiceFabric.AspNetCore.HttpSys.csproj
@@ -15,7 +15,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.1.12" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.ServiceFabric.AspNetCore\Microsoft.ServiceFabric.AspNetCore.csproj" />

--- a/src/Microsoft.ServiceFabric.AspNetCore.HttpSys/Microsoft.ServiceFabric.AspNetCore.HttpSys.csproj
+++ b/src/Microsoft.ServiceFabric.AspNetCore.HttpSys/Microsoft.ServiceFabric.AspNetCore.HttpSys.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.ServiceFabric.Services.Communication.AspNetCore</RootNamespace>
     <AssemblyName>Microsoft.ServiceFabric.AspNetCore.HttpSys</AssemblyName>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric" Version="$(NugetPkg_Version_Microsoft_ServiceFabric)" />

--- a/src/Microsoft.ServiceFabric.AspNetCore.Kestrel/Microsoft.ServiceFabric.AspNetCore.Kestrel.csproj
+++ b/src/Microsoft.ServiceFabric.AspNetCore.Kestrel/Microsoft.ServiceFabric.AspNetCore.Kestrel.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Microsoft.ServiceFabric.AspNetCore.Kestrel</AssemblyName>
     <RootNamespace>Microsoft.ServiceFabric.Services.Communication.AspNetCore</RootNamespace>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric" Version="$(NugetPkg_Version_Microsoft_ServiceFabric)" />

--- a/src/Microsoft.ServiceFabric.AspNetCore/Microsoft.ServiceFabric.AspNetCore.csproj
+++ b/src/Microsoft.ServiceFabric.AspNetCore/Microsoft.ServiceFabric.AspNetCore.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Microsoft.ServiceFabric.AspNetCore</AssemblyName>
     <RootNamespace>Microsoft.ServiceFabric.Services.Communication.AspNetCore</RootNamespace>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric.Services" Version="$(NugetPkg_Version_Microsoft_ServiceFabric_Services)" />

--- a/test/unittests/Microsoft.ServiceFabric.AspNetCore.Tests/Microsoft.ServiceFabric.AspNetCore.Tests.csproj
+++ b/test/unittests/Microsoft.ServiceFabric.AspNetCore.Tests/Microsoft.ServiceFabric.AspNetCore.Tests.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.ServiceFabric.AspNetCore.Tests</AssemblyName>
     <RootNamespace>Microsoft.ServiceFabric.AspNetCore.Tests</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/test/unittests/Microsoft.ServiceFabric.AspNetCore.Tests/Mocks/TestHelper.cs
+++ b/test/unittests/Microsoft.ServiceFabric.AspNetCore.Tests/Mocks/TestHelper.cs
@@ -21,7 +21,9 @@ namespace Microsoft.ServiceFabric.AspNetCore.Tests
         public static T CreateInstanced<T>()
             where T : class
         {
+#pragma warning disable SYSLIB0050 // FormatterServices is obsolete
             return FormatterServices.GetSafeUninitializedObject(typeof(T)) as T;
+#pragma warning restore SYSLIB0050
         }
 
         public static T Set<T>(this T instance, string property, object value)

--- a/test/unittests/Microsoft.ServiceFabric.AspNetCore.Tests/ServiceFabricMiddlewareTests.cs
+++ b/test/unittests/Microsoft.ServiceFabric.AspNetCore.Tests/ServiceFabricMiddlewareTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.ServiceFabric.AspNetCore.Tests
                 (httpContext) =>
             {
                 nextCalled = true;
-                return Task.FromResult(true);
+                return Task.CompletedTask;
             }, this.listener.UrlSuffix);
 
             // send a request in which Path is different than urlSuffix
@@ -165,7 +165,7 @@ namespace Microsoft.ServiceFabric.AspNetCore.Tests
                 nextCalled = true;
                 Console.WriteLine("In Next Request Delegate: HttpRequest.Path: " + httpContext.Request.Path);
                 Console.WriteLine("In Next Request Delegate: HttpRequest.PathBase: " + httpContext.Request.PathBase);
-                return Task.FromResult(true);
+                return Task.CompletedTask;
             }, this.listener.UrlSuffix);
 
             // send a request in which Path is same as urlSuffix
@@ -198,7 +198,7 @@ namespace Microsoft.ServiceFabric.AspNetCore.Tests
                 Console.WriteLine("In Next Request Delegate: HttpRequest.PathBase: " + httpContext.Request.PathBase);
 
                 nextCalled = true;
-                return Task.FromResult(true);
+                return Task.CompletedTask;
             }, this.listener.UrlSuffix);
 
             // send a request in which Path is different than urlSuffix, but has extra segment after it.


### PR DESCRIPTION
- Add net8.0 to TargetFrameworks of C# projects
- Add net8.0 binaries to NuGet projects
- Change tests from net6.0 to net8.0
- Increase HttpSys reference to 2.1.12 to fix security vulnerability reported as build error
- Make tests define RequestDelegate with correct return type to fix net8.0 build error

https://dev.azure.com/msazure/One/_workitems/edit/27071017