### PR TITLE
Migrate build to the official OneBranch template

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,7 @@
+{
+    "instanceUrl": "https://msazure.visualstudio.com",
+    "projectName": "One",
+    "areaPath": "One\\Service Fabric\\Programming Model",
+    "notificationAliases": [ "sfprogmodel@microsoft.com" ],
+    "codebaseName": "service-fabric-aspnetcore"
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Azure/service-fabric-aspnetcore
+# Service Fabric ASP.NET Core Packages
+
+[![Build Status](https://dev.azure.com/msazure/One/_apis/build/status/OneBranch/WindowsFabric/service-fabric-aspnetcore?branchName=develop)](https://dev.azure.com/msazure/One/_build/latest?definitionId=365964&branchName=develop)
 
 This repo contains ASP.NET Core integration for Service Fabric Reliable Services.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,86 @@
+trigger:
+  branches:
+    include:
+    - develop
+    - releases_*
+
+pr: none # PR validation is out of scope for now
+
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+
+variables: # Expected by OneBranch template
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'
+
+extends:
+  template: v2/OneBranch.Official.CrossPlat.yml@templates
+  parameters:
+    featureFlags:
+      WindowsHostVersion: 1ESWindows2022
+    globalSdl:
+      asyncSdl: # Fails to retrieve TsaOptions.json from GitHub
+        enabled: false
+    stages:
+    - stage: main
+      jobs:
+      - job: job
+        pool:
+          type: windows
+        variables: 
+          ob_outputDirectory: '$(Build.SourcesDirectory)\drop'
+        steps:
+        - pwsh: ./build.ps1 -Target BuildCode
+          displayName: Build
+        - pwsh: dotnet test code.sln --configuration release --nologo --settings test\unittests\default.runsettings --results-directory $(ob_outputDirectory) --logger trx
+          displayName: Test
+        - task: onebranch.pipeline.signing@1
+          displayName: Sign assemblies
+          inputs:
+            command: sign
+            signing_profile: external_distribution
+            files_to_sign: '**/*.dll'
+            search_root: $(ob_outputDirectory)
+        - pwsh: ./build.ps1 -Target GeneratePackages
+          displayName: Package
+        - task: onebranch.pipeline.signing@1
+          displayName: Sign packages
+          inputs:
+            command: sign
+            signing_profile: external_distribution
+            files_to_sign: '**/*.nupkg'
+            search_root: $(ob_outputDirectory)
+        - task: NuGetCommand@2
+          displayName: 'Publish to Internal Feed' # For builds on Windows
+          inputs:
+            command: 'push'
+            packagesToPush: '$(ob_outputDirectory)\Release\packages\SF.AspNetCore.Internal.*.nupkg'
+            nuGetFeedType: 'internal'
+            publishVstsFeed: 'one/service-fabric-services-and-actors-dotnet'
+          continueOnError: true
+        - task: PowerShell@2
+          displayName: 'Update Az Module' # For AzureFileCopy@6
+          inputs:
+            targetType: 'inline'
+            script: |
+              get-module Azure* -ListAvailable -All | 
+                Select-Object -expandproperty ModuleBase | 
+                foreach-object {remove-Item -filter * -recurse -path $_ -erroraction ignore}
+
+              Get-PackageProvider -Name NuGet -ForceBootstrap
+              install-module Az.Accounts -MinimumVersion 2.2.0 -verbose -force -AllowClobber
+              Install-Module Az.Resources -verbose -force -AllowClobber
+              Install-Module Az.Storage -verbose -force -AllowClobber
+              get-module Azure* -ListAvailable -All
+        - task: AzureFileCopy@6
+          displayName: 'Publish to Blob Storage' # For builds on Linux
+          inputs:
+            SourcePath: '$(ob_outputDirectory)\Release\packages\SF.AspNetCore.Internal.*.nupkg'
+            azureSubscription: 'SF-EngSystemsSubscription'
+            Destination: AzureBlob
+            storage: sfprebuiltinternal212418
+            ContainerName: binaries
+          continueOnError: true

--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -31,7 +31,7 @@
     <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->
     <MajorVersion>8</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <BuildVersion>1</BuildVersion>
+    <BuildVersion>3</BuildVersion>
     <Revision>0</Revision>
 
   </PropertyGroup>


### PR DESCRIPTION
- Create `azure-pipelines.yml` definition based on the official OneBranch template 
- Create new build based on definition: https://dev.azure.com/msazure/One/_build?definitionId=365964
- Add `tsaoptions.json` used by OneBranch to report bugs for build failures
- Add a build status badge to the `README.md`

ADO work item: https://dev.azure.com/msazure/One/_workitems/edit/27474942
Build example: https://dev.azure.com/msazure/One/_build/results?buildId=94327851 