### PR TITLE
Removing binaries for unsupported .NET versions

### DIFF
--- a/nuprojs/Microsoft.ServiceFabric.AspNetCore.Abstractions/Microsoft.ServiceFabric.AspNetCore.Abstractions.nuproj
+++ b/nuprojs/Microsoft.ServiceFabric.AspNetCore.Abstractions/Microsoft.ServiceFabric.AspNetCore.Abstractions.nuproj
@@ -39,30 +39,6 @@
       <File Include="$(DropFolderNetFramework)\Microsoft.ServiceFabric.AspNetCore.xml">
         <TargetPath>lib\net472</TargetPath>
       </File>
-      <File Include="$(DropFolderNetCore)Microsoft.ServiceFabric.AspNetCore.dll">
-        <TargetPath>lib\netcoreapp3.1</TargetPath>
-      </File>
-      <File Include="$(DropFolderNetCore)Microsoft.ServiceFabric.AspNetCore.xml">
-        <TargetPath>lib\netcoreapp3.1</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet5)Microsoft.ServiceFabric.AspNetCore.xml">
-        <TargetPath>lib\net5.0</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet5)Microsoft.ServiceFabric.AspNetCore.dll">
-        <TargetPath>lib\net5.0</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet6)Microsoft.ServiceFabric.AspNetCore.xml">
-        <TargetPath>lib\net6.0</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet6)Microsoft.ServiceFabric.AspNetCore.dll">
-        <TargetPath>lib\net6.0</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet7)Microsoft.ServiceFabric.AspNetCore.xml">
-        <TargetPath>lib\net7.0</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet7)Microsoft.ServiceFabric.AspNetCore.dll">
-        <TargetPath>lib\net7.0</TargetPath>
-      </File>
       <File Include="$(DropFolderNet8)Microsoft.ServiceFabric.AspNetCore.xml">
         <TargetPath>lib\net8.0</TargetPath>
       </File>
@@ -84,38 +60,6 @@
     </ItemGroup>
     
     <ItemGroup>
-      <Dependency Include="Microsoft.ServiceFabric.Services">
-        <Version>[$(NugetPkg_Version_Microsoft_ServiceFabric_Services)]</Version>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-      </Dependency>
-      <FrameworkReference Include="Microsoft.AspNetCore.App">
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-      </FrameworkReference>
-
-      <Dependency Include="Microsoft.ServiceFabric.Services">
-        <Version>[$(NugetPkg_Version_Microsoft_ServiceFabric_Services)]</Version>
-        <TargetFramework>net5.0</TargetFramework>
-      </Dependency>
-      <FrameworkReference Include="Microsoft.AspNetCore.App">
-        <TargetFramework>net5.0</TargetFramework>
-      </FrameworkReference>
-
-      <Dependency Include="Microsoft.ServiceFabric.Services">
-        <Version>[$(NugetPkg_Version_Microsoft_ServiceFabric_Services)]</Version>
-        <TargetFramework>net6.0</TargetFramework>
-      </Dependency>
-      <FrameworkReference Include="Microsoft.AspNetCore.App">
-        <TargetFramework>net6.0</TargetFramework>
-      </FrameworkReference>
-
-      <Dependency Include="Microsoft.ServiceFabric.Services">
-        <Version>[$(NugetPkg_Version_Microsoft_ServiceFabric_Services)]</Version>
-        <TargetFramework>net7.0</TargetFramework>
-      </Dependency>
-      <FrameworkReference Include="Microsoft.AspNetCore.App">
-        <TargetFramework>net7.0</TargetFramework>
-      </FrameworkReference>
-
       <Dependency Include="Microsoft.ServiceFabric.Services">
         <Version>[$(NugetPkg_Version_Microsoft_ServiceFabric_Services)]</Version>
         <TargetFramework>net8.0</TargetFramework>

--- a/nuprojs/Microsoft.ServiceFabric.AspNetCore.Configuration/Microsoft.ServiceFabric.AspNetCore.Configuration.nuproj
+++ b/nuprojs/Microsoft.ServiceFabric.AspNetCore.Configuration/Microsoft.ServiceFabric.AspNetCore.Configuration.nuproj
@@ -39,30 +39,6 @@
       <File Include="$(DropFolderNetFramework)\Microsoft.ServiceFabric.AspNetCore.Configuration.xml">
         <TargetPath>lib\net472</TargetPath>
       </File>
-      <File Include="$(DropFolderNetCore)Microsoft.ServiceFabric.AspNetCore.Configuration.dll">
-        <TargetPath>lib\netcoreapp3.1</TargetPath>
-      </File>
-      <File Include="$(DropFolderNetCore)Microsoft.ServiceFabric.AspNetCore.Configuration.xml">
-        <TargetPath>lib\netcoreapp3.1</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet5)Microsoft.ServiceFabric.AspNetCore.Configuration.dll">
-        <TargetPath>lib\net5.0</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet5)Microsoft.ServiceFabric.AspNetCore.Configuration.xml">
-        <TargetPath>lib\net5.0</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet6)Microsoft.ServiceFabric.AspNetCore.Configuration.dll">
-        <TargetPath>lib\net6.0</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet6)Microsoft.ServiceFabric.AspNetCore.Configuration.xml">
-        <TargetPath>lib\net6.0</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet7)Microsoft.ServiceFabric.AspNetCore.Configuration.dll">
-        <TargetPath>lib\net7.0</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet7)Microsoft.ServiceFabric.AspNetCore.Configuration.xml">
-        <TargetPath>lib\net7.0</TargetPath>
-      </File>
       <File Include="$(DropFolderNet8)Microsoft.ServiceFabric.AspNetCore.Configuration.dll">
         <TargetPath>lib\net8.0</TargetPath>
       </File>
@@ -84,37 +60,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Dependency Include="Microsoft.ServiceFabric.Services">
-        <Version>[$(NugetPkg_Version_Microsoft_ServiceFabric_Services)]</Version>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-      </Dependency>
-      <FrameworkReference Include="Microsoft.AspNetCore.App">
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-      </FrameworkReference>
-
-      <Dependency Include="Microsoft.ServiceFabric.Services">
-        <Version>[$(NugetPkg_Version_Microsoft_ServiceFabric_Services)]</Version>
-        <TargetFramework>net5.0</TargetFramework>
-      </Dependency>
-      <FrameworkReference Include="Microsoft.AspNetCore.App">
-        <TargetFramework>net5.0</TargetFramework>
-      </FrameworkReference>
-
-      <Dependency Include="Microsoft.ServiceFabric.Services">
-        <Version>[$(NugetPkg_Version_Microsoft_ServiceFabric_Services)]</Version>
-        <TargetFramework>net6.0</TargetFramework>
-      </Dependency>
-      <FrameworkReference Include="Microsoft.AspNetCore.App">
-        <TargetFramework>net6.0</TargetFramework>
-      </FrameworkReference>
-
-      <Dependency Include="Microsoft.ServiceFabric.Services">
-        <Version>[$(NugetPkg_Version_Microsoft_ServiceFabric_Services)]</Version>
-        <TargetFramework>net7.0</TargetFramework>
-      </Dependency>
-      <FrameworkReference Include="Microsoft.AspNetCore.App">
-        <TargetFramework>net7.0</TargetFramework>
-      </FrameworkReference>
 
       <Dependency Include="Microsoft.ServiceFabric.Services">
         <Version>[$(NugetPkg_Version_Microsoft_ServiceFabric_Services)]</Version>

--- a/nuprojs/Microsoft.ServiceFabric.AspNetCore.HttpSys/Microsoft.ServiceFabric.AspNetCore.HttpSys.nuproj
+++ b/nuprojs/Microsoft.ServiceFabric.AspNetCore.HttpSys/Microsoft.ServiceFabric.AspNetCore.HttpSys.nuproj
@@ -39,30 +39,6 @@
       <File Include="$(DropFolderNetFramework)\Microsoft.ServiceFabric.AspNetCore.HttpSys.xml">
         <TargetPath>lib\net472</TargetPath>
       </File>
-      <File Include="$(DropFolderNetCore)Microsoft.ServiceFabric.AspNetCore.HttpSys.dll">
-        <TargetPath>lib\netcoreapp3.1</TargetPath>
-      </File>
-      <File Include="$(DropFolderNetCore)Microsoft.ServiceFabric.AspNetCore.HttpSys.xml">
-        <TargetPath>lib\netcoreapp3.1</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet5)Microsoft.ServiceFabric.AspNetCore.HttpSys.dll">
-        <TargetPath>lib\net5.0</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet5)Microsoft.ServiceFabric.AspNetCore.HttpSys.xml">
-        <TargetPath>lib\net5.0</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet6)Microsoft.ServiceFabric.AspNetCore.HttpSys.dll">
-        <TargetPath>lib\net6.0</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet6)Microsoft.ServiceFabric.AspNetCore.HttpSys.xml">
-        <TargetPath>lib\net6.0</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet7)Microsoft.ServiceFabric.AspNetCore.HttpSys.dll">
-        <TargetPath>lib\net7.0</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet7)Microsoft.ServiceFabric.AspNetCore.HttpSys.xml">
-        <TargetPath>lib\net7.0</TargetPath>
-      </File>
       <File Include="$(DropFolderNet8)Microsoft.ServiceFabric.AspNetCore.HttpSys.dll">
         <TargetPath>lib\net8.0</TargetPath>
       </File>
@@ -84,37 +60,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Dependency Include="Microsoft.ServiceFabric.AspNetCore.Abstractions">
-        <Version>[$(NuGetPackageVersion)]</Version>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-      </Dependency>
-      <FrameworkReference Include="Microsoft.AspNetCore.App">
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-      </FrameworkReference>
-
-      <Dependency Include="Microsoft.ServiceFabric.AspNetCore.Abstractions">
-        <Version>[$(NuGetPackageVersion)]</Version>
-        <TargetFramework>net5.0</TargetFramework>
-      </Dependency>
-      <FrameworkReference Include="Microsoft.AspNetCore.App">
-        <TargetFramework>net5.0</TargetFramework>
-      </FrameworkReference>
-
-      <Dependency Include="Microsoft.ServiceFabric.AspNetCore.Abstractions">
-        <Version>[$(NuGetPackageVersion)]</Version>
-        <TargetFramework>net6.0</TargetFramework>
-      </Dependency>
-      <FrameworkReference Include="Microsoft.AspNetCore.App">
-        <TargetFramework>net6.0</TargetFramework>
-      </FrameworkReference>
-
-      <Dependency Include="Microsoft.ServiceFabric.AspNetCore.Abstractions">
-        <Version>[$(NuGetPackageVersion)]</Version>
-        <TargetFramework>net7.0</TargetFramework>
-      </Dependency>
-      <FrameworkReference Include="Microsoft.AspNetCore.App">
-        <TargetFramework>net7.0</TargetFramework>
-      </FrameworkReference>
 
       <Dependency Include="Microsoft.ServiceFabric.AspNetCore.Abstractions">
         <Version>[$(NuGetPackageVersion)]</Version>

--- a/nuprojs/Microsoft.ServiceFabric.AspNetCore.Kestrel/Microsoft.ServiceFabric.AspNetCore.Kestrel.nuproj
+++ b/nuprojs/Microsoft.ServiceFabric.AspNetCore.Kestrel/Microsoft.ServiceFabric.AspNetCore.Kestrel.nuproj
@@ -39,30 +39,6 @@
       <File Include="$(DropFolderNetFramework)\Microsoft.ServiceFabric.AspNetCore.Kestrel.xml">
         <TargetPath>lib\net472</TargetPath>
       </File>
-      <File Include="$(DropFolderNetCore)Microsoft.ServiceFabric.AspNetCore.Kestrel.dll">
-        <TargetPath>lib\netcoreapp3.1</TargetPath>
-      </File>
-      <File Include="$(DropFolderNetCore)Microsoft.ServiceFabric.AspNetCore.Kestrel.xml">
-        <TargetPath>lib\netcoreapp3.1</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet5)Microsoft.ServiceFabric.AspNetCore.Kestrel.dll">
-        <TargetPath>lib\net5.0</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet5)Microsoft.ServiceFabric.AspNetCore.Kestrel.xml">
-        <TargetPath>lib\net5.0</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet6)Microsoft.ServiceFabric.AspNetCore.Kestrel.dll">
-        <TargetPath>lib\net6.0</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet6)Microsoft.ServiceFabric.AspNetCore.Kestrel.xml">
-        <TargetPath>lib\net6.0</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet7)Microsoft.ServiceFabric.AspNetCore.Kestrel.dll">
-        <TargetPath>lib\net7.0</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet7)Microsoft.ServiceFabric.AspNetCore.Kestrel.xml">
-       <TargetPath>lib\net7.0</TargetPath>
-      </File>
       <File Include="$(DropFolderNet8)Microsoft.ServiceFabric.AspNetCore.Kestrel.dll">
         <TargetPath>lib\net8.0</TargetPath>
       </File>
@@ -84,37 +60,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Dependency Include="Microsoft.ServiceFabric.AspNetCore.Abstractions">
-        <Version>[$(NuGetPackageVersion)]</Version>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-      </Dependency>
-      <FrameworkReference Include="Microsoft.AspNetCore.App">
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-      </FrameworkReference>
-
-      <Dependency Include="Microsoft.ServiceFabric.AspNetCore.Abstractions">
-        <Version>[$(NuGetPackageVersion)]</Version>
-        <TargetFramework>net5.0</TargetFramework>
-      </Dependency>
-      <FrameworkReference Include="Microsoft.AspNetCore.App">
-        <TargetFramework>net5.0</TargetFramework>
-      </FrameworkReference>
-
-      <Dependency Include="Microsoft.ServiceFabric.AspNetCore.Abstractions">
-        <Version>[$(NuGetPackageVersion)]</Version>
-        <TargetFramework>net6.0</TargetFramework>
-      </Dependency>
-      <FrameworkReference Include="Microsoft.AspNetCore.App">
-        <TargetFramework>net6.0</TargetFramework>
-      </FrameworkReference>
-
-      <Dependency Include="Microsoft.ServiceFabric.AspNetCore.Abstractions">
-        <Version>[$(NuGetPackageVersion)]</Version>
-        <TargetFramework>net7.0</TargetFramework>
-      </Dependency>
-      <FrameworkReference Include="Microsoft.AspNetCore.App">
-        <TargetFramework>net7.0</TargetFramework>
-      </FrameworkReference>
 
       <Dependency Include="Microsoft.ServiceFabric.AspNetCore.Abstractions">
         <Version>[$(NuGetPackageVersion)]</Version>

--- a/nuprojs/SF.AspNetCore.Internal/SF.AspNetCore.Internal.nuproj
+++ b/nuprojs/SF.AspNetCore.Internal/SF.AspNetCore.Internal.nuproj
@@ -18,18 +18,6 @@
       <File Include="$(DropFolderNetFramework)*.*">
         <TargetPath>lib\netframework</TargetPath>
       </File>
-      <File Include="$(DropFolderNetCore)*.*">
-        <TargetPath>lib\netcoreapp3.1</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet5)*.*">
-        <TargetPath>lib\net5.0</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet6)*.*">
-        <TargetPath>lib\net6.0</TargetPath>
-      </File>
-      <File Include="$(DropFolderNet7)*.*">
-        <TargetPath>lib\net7.0</TargetPath>
-      </File>
       <File Include="$(DropFolderNet8)*.*">
         <TargetPath>lib\net8.0</TargetPath>
       </File>

--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -27,7 +27,7 @@
     <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->
     <MajorVersion>8</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <BuildVersion>3</BuildVersion>
+    <BuildVersion>4</BuildVersion>
     <Revision>0</Revision>
 
   </PropertyGroup>

--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -13,10 +13,6 @@
     <!-- Set Drop folders -->
     <DropFolder>$(RepoRoot)drop\$(Configuration)\</DropFolder>
     <DropFolderNetFramework>$(RepoRoot)drop\$(Configuration)\net462\</DropFolderNetFramework>
-    <DropFolderNetCore>$(RepoRoot)drop\$(Configuration)\netcoreapp3.1\</DropFolderNetCore>
-    <DropFolderNet5>$(RepoRoot)drop\$(Configuration)\net5.0\</DropFolderNet5>
-    <DropFolderNet6>$(RepoRoot)drop\$(Configuration)\net6.0\</DropFolderNet6>
-    <DropFolderNet7>$(RepoRoot)drop\$(Configuration)\net7.0\</DropFolderNet7>
     <DropFolderNet8>$(RepoRoot)drop\$(Configuration)\net8.0\</DropFolderNet8>
     <NugetPackageDropFolder>$(DropFolder)\packages</NugetPackageDropFolder>
 

--- a/properties/service_fabric_managed.targets
+++ b/properties/service_fabric_managed.targets
@@ -57,38 +57,6 @@
     <Copy SourceFiles="@(BinariesNetFramework)" DestinationFiles="@(BinariesNetFramework->'$(DropFolderNetFramework)\%(Destination)\%(RecursiveDir)%(Filename)%(Extension)')" />
 
     <ItemGroup>
-      <BinariesNetCore Include="src\Microsoft.ServiceFabric.AspNetCore\$(OutputPath)netcoreapp3.1\Microsoft.ServiceFabric.AspNetCore.*"/>
-      <BinariesNetCore Include="src\Microsoft.ServiceFabric.AspNetCore.Configuration\$(OutputPath)netcoreapp3.1\Microsoft.ServiceFabric.AspNetCore.Configuration.*"/>
-      <BinariesNetCore Include="src\Microsoft.ServiceFabric.AspNetCore.HttpSys\$(OutputPath)netcoreapp3.1\Microsoft.ServiceFabric.AspNetCore.HttpSys.*"/>
-      <BinariesNetCore Include="src\Microsoft.ServiceFabric.AspNetCore.Kestrel\$(OutputPath)netcoreapp3.1\Microsoft.ServiceFabric.AspNetCore.Kestrel.*"/>
-    </ItemGroup>
-    <Copy SourceFiles="@(BinariesNetCore)" DestinationFiles="@(BinariesNetCore->'$(DropFolderNetCore)\%(Destination)\%(RecursiveDir)%(Filename)%(Extension)')" />
-
-    <ItemGroup>
-      <BinariesNet5 Include="src\Microsoft.ServiceFabric.AspNetCore\$(OutputPath)net5.0\Microsoft.ServiceFabric.AspNetCore.*"/>
-      <BinariesNet5 Include="src\Microsoft.ServiceFabric.AspNetCore.Configuration\$(OutputPath)net5.0\Microsoft.ServiceFabric.AspNetCore.Configuration.*"/>
-      <BinariesNet5 Include="src\Microsoft.ServiceFabric.AspNetCore.HttpSys\$(OutputPath)net5.0\Microsoft.ServiceFabric.AspNetCore.HttpSys.*"/>
-      <BinariesNet5 Include="src\Microsoft.ServiceFabric.AspNetCore.Kestrel\$(OutputPath)net5.0\Microsoft.ServiceFabric.AspNetCore.Kestrel.*"/>
-    </ItemGroup>
-    <Copy SourceFiles="@(BinariesNet5)" DestinationFiles="@(BinariesNet5->'$(DropFolderNet5)\%(Destination)\%(RecursiveDir)%(Filename)%(Extension)')" />
-
-    <ItemGroup>
-      <BinariesNet6 Include="src\Microsoft.ServiceFabric.AspNetCore\$(OutputPath)net6.0\Microsoft.ServiceFabric.AspNetCore.*"/>
-      <BinariesNet6 Include="src\Microsoft.ServiceFabric.AspNetCore.Configuration\$(OutputPath)net6.0\Microsoft.ServiceFabric.AspNetCore.Configuration.*"/>
-      <BinariesNet6 Include="src\Microsoft.ServiceFabric.AspNetCore.HttpSys\$(OutputPath)net6.0\Microsoft.ServiceFabric.AspNetCore.HttpSys.*"/>
-      <BinariesNet6 Include="src\Microsoft.ServiceFabric.AspNetCore.Kestrel\$(OutputPath)net6.0\Microsoft.ServiceFabric.AspNetCore.Kestrel.*"/>
-    </ItemGroup>
-    <Copy SourceFiles="@(BinariesNet6)" DestinationFiles="@(BinariesNet6->'$(DropFolderNet6)\%(Destination)\%(RecursiveDir)%(Filename)%(Extension)')" />
-
-    <ItemGroup>
-      <BinariesNet7 Include="src\Microsoft.ServiceFabric.AspNetCore\$(OutputPath)net7.0\Microsoft.ServiceFabric.AspNetCore.*"/>
-      <BinariesNet7 Include="src\Microsoft.ServiceFabric.AspNetCore.Configuration\$(OutputPath)net7.0\Microsoft.ServiceFabric.AspNetCore.Configuration.*"/>
-      <BinariesNet7 Include="src\Microsoft.ServiceFabric.AspNetCore.HttpSys\$(OutputPath)net7.0\Microsoft.ServiceFabric.AspNetCore.HttpSys.*"/>
-      <BinariesNet7 Include="src\Microsoft.ServiceFabric.AspNetCore.Kestrel\$(OutputPath)net7.0\Microsoft.ServiceFabric.AspNetCore.Kestrel.*"/>
-    </ItemGroup>
-    <Copy SourceFiles="@(BinariesNet7)" DestinationFiles="@(BinariesNet7->'$(DropFolderNet7)\%(Destination)\%(RecursiveDir)%(Filename)%(Extension)')" />
-
-    <ItemGroup>
       <BinariesNet8 Include="src\Microsoft.ServiceFabric.AspNetCore\$(OutputPath)net8.0\Microsoft.ServiceFabric.AspNetCore.*"/>
       <BinariesNet8 Include="src\Microsoft.ServiceFabric.AspNetCore.Configuration\$(OutputPath)net8.0\Microsoft.ServiceFabric.AspNetCore.Configuration.*"/>
       <BinariesNet8 Include="src\Microsoft.ServiceFabric.AspNetCore.HttpSys\$(OutputPath)net8.0\Microsoft.ServiceFabric.AspNetCore.HttpSys.*"/>

--- a/src/Microsoft.ServiceFabric.AspNetCore.Configuration/Microsoft.ServiceFabric.AspNetCore.Configuration.csproj
+++ b/src/Microsoft.ServiceFabric.AspNetCore.Configuration/Microsoft.ServiceFabric.AspNetCore.Configuration.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Microsoft.ServiceFabric.AspNetCore.Configuration</AssemblyName>
     <RootNamespace>Microsoft.ServiceFabric.AspNetCore.Configuration</RootNamespace>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric.Services" Version="$(NugetPkg_Version_Microsoft_ServiceFabric_Services)" />

--- a/src/Microsoft.ServiceFabric.AspNetCore.HttpSys/Microsoft.ServiceFabric.AspNetCore.HttpSys.csproj
+++ b/src/Microsoft.ServiceFabric.AspNetCore.HttpSys/Microsoft.ServiceFabric.AspNetCore.HttpSys.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.ServiceFabric.Services.Communication.AspNetCore</RootNamespace>
     <AssemblyName>Microsoft.ServiceFabric.AspNetCore.HttpSys</AssemblyName>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric" Version="$(NugetPkg_Version_Microsoft_ServiceFabric)" />

--- a/src/Microsoft.ServiceFabric.AspNetCore.Kestrel/Microsoft.ServiceFabric.AspNetCore.Kestrel.csproj
+++ b/src/Microsoft.ServiceFabric.AspNetCore.Kestrel/Microsoft.ServiceFabric.AspNetCore.Kestrel.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Microsoft.ServiceFabric.AspNetCore.Kestrel</AssemblyName>
     <RootNamespace>Microsoft.ServiceFabric.Services.Communication.AspNetCore</RootNamespace>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric" Version="$(NugetPkg_Version_Microsoft_ServiceFabric)" />

--- a/src/Microsoft.ServiceFabric.AspNetCore/Microsoft.ServiceFabric.AspNetCore.csproj
+++ b/src/Microsoft.ServiceFabric.AspNetCore/Microsoft.ServiceFabric.AspNetCore.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Microsoft.ServiceFabric.AspNetCore</AssemblyName>
     <RootNamespace>Microsoft.ServiceFabric.Services.Communication.AspNetCore</RootNamespace>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric.Services" Version="$(NugetPkg_Version_Microsoft_ServiceFabric_Services)" />


### PR DESCRIPTION
Removing binaries for:

- netcore3.1
- net5.0
- net6.0 (will be unsupported by the time the next major version of SDK ships)
- net7.0