### PR TITLE
Resolving vulnerable transitive dependencies

### DIFF
--- a/src/Microsoft.ServiceFabric.AspNetCore.Kestrel/Microsoft.ServiceFabric.AspNetCore.Kestrel.csproj
+++ b/src/Microsoft.ServiceFabric.AspNetCore.Kestrel/Microsoft.ServiceFabric.AspNetCore.Kestrel.csproj
@@ -16,6 +16,9 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.1.25"/>
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.1.40" />
+    <PackageReference Include="System.IO.Pipelines" Version="4.5.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.ServiceFabric.AspNetCore\Microsoft.ServiceFabric.AspNetCore.csproj" />

--- a/src/Microsoft.ServiceFabric.AspNetCore.Kestrel/Microsoft.ServiceFabric.AspNetCore.Kestrel.csproj
+++ b/src/Microsoft.ServiceFabric.AspNetCore.Kestrel/Microsoft.ServiceFabric.AspNetCore.Kestrel.csproj
@@ -15,7 +15,9 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <!-- Direct dependencies -->
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.0" />
+    <!-- Overriding versions of transitive dependencies -->
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.1.25"/>
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.1.40" />
     <PackageReference Include="System.IO.Pipelines" Version="4.5.1" />

--- a/src/Microsoft.ServiceFabric.AspNetCore/Microsoft.ServiceFabric.AspNetCore.csproj
+++ b/src/Microsoft.ServiceFabric.AspNetCore/Microsoft.ServiceFabric.AspNetCore.csproj
@@ -16,6 +16,9 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1"/>
+  </ItemGroup>
+  <ItemGroup>
   </ItemGroup>
   <ItemGroup>
     <Compile Update="SR.Designer.cs">

--- a/src/Microsoft.ServiceFabric.AspNetCore/Microsoft.ServiceFabric.AspNetCore.csproj
+++ b/src/Microsoft.ServiceFabric.AspNetCore/Microsoft.ServiceFabric.AspNetCore.csproj
@@ -15,10 +15,10 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <!-- Direct dependencies -->
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
+    <!-- Overriding versions of transitive dependencies -->
     <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1"/>
-  </ItemGroup>
-  <ItemGroup>
   </ItemGroup>
   <ItemGroup>
     <Compile Update="SR.Designer.cs">


### PR DESCRIPTION
Overriding versions of transitive dependencies that were flagged as vulnerable on nuget.org. Vulnerable transitive dependencies were only identified for net462 builds. 

Internal ADO work item: https://dev.azure.com/msazure/One/_workitems/edit/29603592