### PR TITLE
Enabling .NET 9 tests for SF SDK packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           dotnet-version: '9.0.x'
       - name: Build Everything
         shell: powershell
-        run: dotnet build code.sln
+        run: dotnet build buildAll.proj
       - name: Run Tests
         run: dotnet test code.sln --configuration release --nologo --settings test\unittests\default.runsettings --results-directory ${{ env.TEST_RESULT_DIR }} --logger trx
       - name: upload artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,13 @@ jobs:
       TEST_RESULT_DIR: drop\testresults
     steps:
       - uses: actions/checkout@v1
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       - name: Build Everything
         shell: powershell
-        run: ./build.ps1
+        run: dotnet build code.sln
       - name: Run Tests
         run: dotnet test code.sln --configuration release --nologo --settings test\unittests\default.runsettings --results-directory ${{ env.TEST_RESULT_DIR }} --logger trx
       - name: upload artifacts

--- a/test/unittests/Microsoft.ServiceFabric.AspNetCore.Tests/Microsoft.ServiceFabric.AspNetCore.Tests.csproj
+++ b/test/unittests/Microsoft.ServiceFabric.AspNetCore.Tests/Microsoft.ServiceFabric.AspNetCore.Tests.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.ServiceFabric.AspNetCore.Tests</AssemblyName>
     <RootNamespace>Microsoft.ServiceFabric.AspNetCore.Tests</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/test/unittests/Microsoft.ServiceFabric.AspNetCore.Tests/Microsoft.ServiceFabric.AspNetCore.Tests.csproj
+++ b/test/unittests/Microsoft.ServiceFabric.AspNetCore.Tests/Microsoft.ServiceFabric.AspNetCore.Tests.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.ServiceFabric.AspNetCore.Tests</AssemblyName>
     <RootNamespace>Microsoft.ServiceFabric.AspNetCore.Tests</RootNamespace>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR enables tests for .NET 9 builds. 

Additionally, we are moving away from the `buils.ps1` script, which uses `msbuild` under the hood. Instead, we are moving to the `dotnet` tool, in the aim of streamlining the build process and infrastructure. 

Internal ADO work item: https://dev.azure.com/msazure/One/_workitems/edit/29603235