### PR TITLE
Increment package dependencies for major version increase of Service Fabric runtime and update build to 9.0.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
 
     <!-- Sort packages by name to reduce merge conflicts -->
 
-    <!-- Versions of some transitive dependencies have been overwritten due the the fact that 
+    <!-- Versions of some transitive dependencies have been overwritten due the the fact that
     they have been marked as vulnerable.  -->
 
     <!-- Each time direct dependecies are updated, the transitive
@@ -22,8 +22,8 @@
         <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.1.40" /> <!-- Transitive dependecy -->
         <PackageVersion Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-        <PackageVersion Include="Microsoft.ServiceFabric" Version="11.0.1004" />
-        <PackageVersion Include="Microsoft.ServiceFabric.Services" Version="8.0.1004" />
+        <PackageVersion Include="Microsoft.ServiceFabric" Version="12.0.0-dev.user-cburg-wi-32024996.1003" />
+        <PackageVersion Include="Microsoft.ServiceFabric.Services" Version="9.0.0-dev.user-cburg-wi-32024996.1003" />
         <PackageVersion Include="Moq" Version="4.20.70" />
         <PackageVersion Include="System.IO.Pipelines" Version="8.0.0" /> <!-- Transitive dependecy -->
         <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" /> <!-- Transitive dependecy -->
@@ -31,4 +31,4 @@
         <PackageVersion Include="xunit" Version="2.8.1" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1" />
     </ItemGroup>
-  </Project> 
+  </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,8 +22,8 @@
         <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.1.40" /> <!-- Transitive dependecy -->
         <PackageVersion Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-        <PackageVersion Include="Microsoft.ServiceFabric" Version="12.0.0-dev.user-cburg-wi-32024996.1003" />
-        <PackageVersion Include="Microsoft.ServiceFabric.Services" Version="9.0.0-dev.user-cburg-wi-32024996.1003" />
+        <PackageVersion Include="Microsoft.ServiceFabric" Version="12.0.0-dev.user-cburg-wi-32024996.1005" />
+        <PackageVersion Include="Microsoft.ServiceFabric.Services" Version="9.0.0-dev.user-cburg-wi-32024996.1005" />
         <PackageVersion Include="Moq" Version="4.20.70" />
         <PackageVersion Include="System.IO.Pipelines" Version="8.0.0" /> <!-- Transitive dependecy -->
         <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" /> <!-- Transitive dependecy -->

--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -21,9 +21,9 @@
 
     <!-- Set versions for files and nuget packages nuget packages generated from this repo. -->
     <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->
-    <MajorVersion>8</MajorVersion>
+    <MajorVersion>9</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <BuildVersion>7</BuildVersion>
+    <BuildVersion>0</BuildVersion>
     <Revision>0</Revision>
 
   </PropertyGroup>

--- a/test/unittests/Microsoft.ServiceFabric.AspNetCore.Tests/Mocks/MockConfigurationPackage.cs
+++ b/test/unittests/Microsoft.ServiceFabric.AspNetCore.Tests/Mocks/MockConfigurationPackage.cs
@@ -17,17 +17,20 @@ namespace Microsoft.ServiceFabric.AspNetCore.Tests
     {
         internal static ConfigurationPackage CreateDefaultPackage(IConfiguration config, string packageName)
         {
-            var package = TestHelper.CreateInstanced<ConfigurationPackage>();
-            var settings = TestHelper.CreateInstanced<ConfigurationSettings>();
-            var desc = TestHelper.CreateInstanced<ConfigurationPackageDescription>();
             var basePath = Environment.CurrentDirectory;
-            desc.Set("Name", packageName);
-            package.Set("Settings", settings);
-            package.Set("Path", $"{basePath}\\{packageName}\\PackageRoot\\Config\\");
-            package.Set("Description", desc);
 
+            var settings = TestHelper.CreateInstanced<ConfigurationSettings>();
             var section = TestHelper.CreateInstanced<System.Fabric.Description.ConfigurationSection>();
             settings.Set(nameof(ConfigurationSettings.Sections), MockConfigurationSections.CreateDefault(config));
+
+            var desc = TestHelper.CreateInstanced<ConfigurationPackageDescription>();
+            desc.Set("Name", packageName);
+            desc.Set("Version", "1.0");
+            desc.Set("Path", $"{basePath}\\{packageName}\\PackageRoot\\Config\\");
+            desc.Set("Settings", settings);
+
+            var package = TestHelper.CreateInstanced<ConfigurationPackage>();
+            package.Set("Description", desc);
 
             return package;
         }


### PR DESCRIPTION
These packages need to consume the next major version of the Service Fabric runtime so then their dependencies point to version 12 of it. Then the packages that are generated from this build are consumed by the Service Fabric runtime.

Update build to 9.0.0.0